### PR TITLE
Replaced SQL Query with conrefs for rebrand

### DIFF
--- a/compliance/adoption.md
+++ b/compliance/adoption.md
@@ -470,7 +470,7 @@ When you plan the bucket for a logging instance, consider the following informat
 **Create a custom COS bucket with the storage features and the policies that you identify.** [Learn more](/docs/log-analysis?topic=log-analysis-archiving).
 {: tip}
 
-**Do not configure a long-term retention policy on a COS bucket if you need access to the data and query it with the {{site.data.keyword.sqlquery_short}} service.**
+**Do not configure a long-term retention policy on a COS bucket if you need access to the data and query it with the {{site.data.keyword.sqlquery_long}} service.**
 {: tip}
 
 Use the following table to help you identify the features that you should consider when you create a bucket:
@@ -655,14 +655,14 @@ You can use the {{site.data.keyword.sqlquery_short}} service to query {{site.dat
 {: tip}
 
 
-The {{site.data.keyword.sqlquery_short}} service provides a server-less, no-ETL solution to easily query data stored in {{site.data.keyword.cos_short}}. Underneath, SQL Query uses Apache Spark SQL as its underlying query engine. You can use the {{site.data.keyword.sqlquery_short}} to run SQL queries (that is, `SELECT` statements) to analyze, transform structured and semi-structured data, or clean up rectangular data. You cannot run actions such as `CREATE`, `DELETE`, `INSERT`, and `UPDATE`.
+The {{site.data.keyword.sqlquery_short}} service provides a server-less, no-ETL solution to easily query data stored in {{site.data.keyword.cos_short}}. Underneath, {{site.data.keyword.sqlquery_short}} uses Apache Spark SQL as its underlying query engine. You can use the {{site.data.keyword.sqlquery_short}} to run SQL queries (that is, `SELECT` statements) to analyze, transform structured and semi-structured data, or clean up rectangular data. You cannot run actions such as `CREATE`, `DELETE`, `INSERT`, and `UPDATE`.
 
 The {{site.data.keyword.sqlquery_short}} service can process input data that is read from CSV, JSON, ORC, Parquet, or AVRO files. Archived files from an {{site.data.keyword.at_full_notm}} instance contain data in JSON format. When you use the {{site.data.keyword.sqlquery_short}} service, each query result can be written to a `CSV`, `JSON`, `ORC`, `PARQUET`, or `AVRO` file in an {{site.data.keyword.cos_short}}instance of your choice. 
 
 **When you query an {{site.data.keyword.at_full_notm}} archive file, you must convert the JSON formatted file into `PARQUET` format to be able to query the contents successfully.**
 {: tip}
 
-**Use the {{site.data.keyword.sqlquery_short}} user interface (UI) to develop and test your queries, and the [SQL Query REST API](#restapi) to automate them.**
+**Use the {{site.data.keyword.sqlquery_short}} user interface (UI) to develop and test your queries, and the [{{site.data.keyword.sqlquery_short}} REST API](#restapi) to automate them.**
 {: tip}
 
 **If you plan to use the {{site.data.keyword.sqlquery_short}} service, and you require HIPAA compliance, create a bucket for your archives that uses a custom key to encrypt the data.**


### PR DESCRIPTION
The following link is also supposed to contain SQL Query residuals, but seems to be broken: ttps://cloud.ibm.com/docs/log-analysis?topic=log-analysis-manage_eu_logs
Please check. As soon as the changes are merged, pls. push to prod. Many thanks!