### PR TITLE
Update kr-seo private endpoints and add Syslog UDP private endpoints

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -76,16 +76,16 @@ The following table shows the public API endpoints:
 
 The following table shows the private API endpoints:
 
-| Region                   | Private endpoint                                     | Private IP addresses                      | Ports              | 
+| Region                   | Private endpoint                                     | Private IP addresses                      | Ports              |
 |--------------------------|----------------------------------------------|---------------------------------------------------|--------------------|
-| `Chennai (in-che)`       | `api.private.in-che.logging.cloud.ibm.com`   | 166.9.60.6                                        | TCP 443  \n TCP 80 | 
-| `Dallas (us-south)`      | `api.private.us-south.logging.cloud.ibm.com` | 166.9.16.11   \n 166.9.12.12    \n 166.9.14.2     | TCP 443  \n TCP 80 | 
-| `Frankfurt (eu-de)`      | `api.private.eu-de.logging.cloud.ibm.com`    | 166.9.32.7    \n 166.9.28.2                       | TCP 443  \n TCP 80 | 
-| `London (eu-gb)`         | `api.private.eu-gb.logging.cloud.ibm.com`    | 166.9.36.2    \n 166.9.38.4     \n 166.9.34.2     | TCP 443  \n TCP 80 | 
-| `Osaka (jp-osa)`         | `api.private.jp-osa.logging.cloud.ibm.com`   | 166.9.71.21   \n 166.9.72.19    \n 166.9.70.19    | TCP 443  \n TCP 80 | 
+| `Chennai (in-che)`       | `api.private.in-che.logging.cloud.ibm.com`   | 166.9.60.6                                        | TCP 443  \n TCP 80 |
+| `Dallas (us-south)`      | `api.private.us-south.logging.cloud.ibm.com` | 166.9.16.11   \n 166.9.12.12    \n 166.9.14.2     | TCP 443  \n TCP 80 |
+| `Frankfurt (eu-de)`      | `api.private.eu-de.logging.cloud.ibm.com`    | 166.9.32.7    \n 166.9.28.2                       | TCP 443  \n TCP 80 |
+| `London (eu-gb)`         | `api.private.eu-gb.logging.cloud.ibm.com`    | 166.9.36.2    \n 166.9.38.4     \n 166.9.34.2     | TCP 443  \n TCP 80 |
+| `Osaka (jp-osa)`         | `api.private.jp-osa.logging.cloud.ibm.com`   | 166.9.71.21   \n 166.9.72.19    \n 166.9.70.19    | TCP 443  \n TCP 80 |
 | `Sao Paulo (br-sao)`     | `api.private.br-sao.logging.cloud.ibm.com`   | 163.107.67.3  \n 163.107.68.196 \n 163.109.68.98  | TCP 443  \n TCP 80 |
-| `Seoul (kr-seo)`         | `api.private.kr-seo.logging.cloud.ibm.com`   | 166.9.46.5                                        | TCP 443  \n TCP 80 | 
-| `Sydney (au-syd)`        | `api.private.au-syd.logging.cloud.ibm.com`   | 166.9.56.3    \n 166.9.52.2                       | TCP 443  \n TCP 80 | 
+| `Seoul (kr-seo)`         | `api.private.kr-seo.logging.cloud.ibm.com`   | 166.9.44.109  \n 166.9.42.119   \n 166.9.40.110   | TCP 443  \n TCP 80 |
+| `Sydney (au-syd)`        | `api.private.au-syd.logging.cloud.ibm.com`   | 166.9.56.3    \n 166.9.52.2                       | TCP 443  \n TCP 80 |
 | `Tokyo (jp-tok)`         | `api.private.jp-tok.logging.cloud.ibm.com`   | 166.9.40.2    \n 166.9.42.3                       | TCP 443  \n TCP 80 |
 | `Toronto (ca-tor)`       | `api.private.ca-tor.logging.cloud.ibm.com`   | 169.53.161.75 \n 163.74.65.133  \n 163.75.73.42   | TCP 443  \n TCP 80 |
 | `Washington (us-east)`   | `api.private.us-east.logging.cloud.ibm.com`  | 166.9.22.35   \n 166.9.20.72                      | TCP 443  \n TCP 80 |
@@ -101,19 +101,19 @@ The following table shows the private API endpoints:
 
 The following table shows the ingestion endpoints:
 
-| Region                 | Ingestion endpoint                          | Public IP addresses                                   | Ports               | 
-|------------------------|---------------------------------------------|-------------------------------------------------------|---------------------|
-| `Chennai (in-che)`     | `logs.in-che.logging.cloud.ibm.com`         | 169.38.75.46                                          | TCP 443  \n TCP 80 | 
-| `Dallas (us-south)`    | `logs.us-south.logging.cloud.ibm.com`       | 169.61.197.84   \n 50.22.153.155  \n 67.228.211.6     | TCP 443  \n TCP 80 | 
-| `Frankfurt (eu-de)`    | `logs.eu-de.logging.cloud.ibm.com`          | 149.81.108.173  \n 158.177.157.66 \n 161.156.78.142   | TCP 443  \n TCP 80 | 
-| `London (eu-gb)`       | `logs.eu-gb.logging.cloud.ibm.com`          | 158.176.163.117 \n 158.175.113.18 \n 141.125.102.149  | TCP 443  \n TCP 80 | 
-| `Osaka (jp-osa)`       | `logs.jp-osa.logging.cloud.ibm.com`         | 163.73.68.44    \n 163.69.67.212  \n 163.68.73.62     | TCP 443  \n TCP 80 | 
-| `Seoul (kr-seo)`       | `logs.kr-seo.logging.cloud.ibm.com`         | 169.56.98.142                                         | TCP 443  \n TCP 80 | 
-| `Sydney (au-syd)`      | `logs.au-syd.logging.cloud.ibm.com`         | 168.1.27.60     \n 130.198.1.213  \n 135.90.67.172    | TCP 443  \n TCP 80 | 
-| `Tokyo (jp-tok)`       | `logs.jp-tok.logging.cloud.ibm.com`         | 128.168.107.243 \n 165.192.100.74 \n 169.56.11.253    | TCP 443  \n TCP 80 | 
-| `Toronto (ca-tor)`     | `logs.ca-tor.logging.cloud.ibm.com`         | 163.74.65.131   \n 169.55.135.27  \n 163.75.66.243    | TCP 443  \n TCP 80 | 
-| `Washington (us-east)` | `logs.us-east.logging.cloud.ibm.com`        | 169.47.134.84   \n 169.60.98.94   \n 169.61.98.204    | TCP 443  \n TCP 80 | 
-| `Sao Paulo (br-sao)`   | `logs.br-sao.logging.cloud.ibm.com`         | 163.109.68.108  \n 163.107.69.13  \n 169.57.152.195   | TCP 443  \n TCP 80 | 
+| Region                 | Ingestion endpoint                          | Public IP addresses                                   | Ports              |
+|------------------------|---------------------------------------------|-------------------------------------------------------|--------------------|
+| `Chennai (in-che)`     | `logs.in-che.logging.cloud.ibm.com`         | 169.38.75.46                                          | TCP 443  \n TCP 80 |
+| `Dallas (us-south)`    | `logs.us-south.logging.cloud.ibm.com`       | 169.61.197.84   \n 50.22.153.155  \n 67.228.211.6     | TCP 443  \n TCP 80 |
+| `Frankfurt (eu-de)`    | `logs.eu-de.logging.cloud.ibm.com`          | 149.81.108.173  \n 158.177.157.66 \n 161.156.78.142   | TCP 443  \n TCP 80 |
+| `London (eu-gb)`       | `logs.eu-gb.logging.cloud.ibm.com`          | 158.176.163.117 \n 158.175.113.18 \n 141.125.102.149  | TCP 443  \n TCP 80 |
+| `Osaka (jp-osa)`       | `logs.jp-osa.logging.cloud.ibm.com`         | 163.73.68.44    \n 163.69.67.212  \n 163.68.73.62     | TCP 443  \n TCP 80 |
+| `Seoul (kr-seo)`       | `logs.kr-seo.logging.cloud.ibm.com`         | 169.56.98.142                                         | TCP 443  \n TCP 80 |
+| `Sydney (au-syd)`      | `logs.au-syd.logging.cloud.ibm.com`         | 168.1.27.60     \n 130.198.1.213  \n 135.90.67.172    | TCP 443  \n TCP 80 |
+| `Tokyo (jp-tok)`       | `logs.jp-tok.logging.cloud.ibm.com`         | 128.168.107.243 \n 165.192.100.74 \n 169.56.11.253    | TCP 443  \n TCP 80 |
+| `Toronto (ca-tor)`     | `logs.ca-tor.logging.cloud.ibm.com`         | 163.74.65.131   \n 169.55.135.27  \n 163.75.66.243    | TCP 443  \n TCP 80 |
+| `Washington (us-east)` | `logs.us-east.logging.cloud.ibm.com`        | 169.47.134.84   \n 169.60.98.94   \n 169.61.98.204    | TCP 443  \n TCP 80 |
+| `Sao Paulo (br-sao)`   | `logs.br-sao.logging.cloud.ibm.com`         | 163.109.68.108  \n 163.107.69.13  \n 169.57.152.195   | TCP 443  \n TCP 80 |
 {: caption="Table 3. Lists of public ingestion endpoints for interacting with {{site.data.keyword.la_full_notm}}" caption-side="top"}
 
 
@@ -124,19 +124,19 @@ The following table shows the ingestion endpoints:
 The following table shows the private ingestion endpoints:
 
 
-| Region                   | Private endpoint                                       | Private IP addresses                | Ports              | 
-|--------------------------|--------------------------------------------------------|-------------------------------------|--------------------|
-| `Chennai (in-che)`       | `logs.private.in-che.logging.cloud.ibm.com`    | 166.9.60.7                                  | TCP 443  \n TCP 80 | 
-| `Dallas (us-south)`      | `logs.private.us-south.logging.cloud.ibm.com`  | 166.9.14.3  \n 166.9.12.13  \n 166.9.16.12  | TCP 443  \n TCP 80 | 
-| `Frankfurt (eu-de)`      | `logs.private.eu-de.logging.cloud.ibm.com`     | 166.9.28.3  \n 166.9.32.21                  | TCP 443  \n TCP 80 | 
-| `London (eu-gb)`         | `logs.private.eu-gb.logging.cloud.ibm.com`     | 166.9.36.3  \n 166.9.34.4  \n 166.9.38.5    | TCP 443  \n TCP 80 | 
-| `Osaka (jp-osa)`         | `logs.private.jp-osa.logging.cloud.ibm.com`    | 166.9.71.20  \n 166.9.70.21  \n 166.9.72.21 | TCP 443  \n TCP 80 | 
-| `Sao Paulo (br-sao)`     | `logs.private.br-sao.logging.cloud.ibm.com`    | 166.9.83.25  \n 166.9.84.27  \n 166.9.82.25 | TCP 443  \n TCP 80 | 
-| `Seoul (kr-seo)`         | `logs.private.kr-seo.logging.cloud.ibm.com`    | 166.9.46.6                                  | TCP 443  \n TCP 80 | 
-| `Sydney (au-syd)`        | `logs.private.au-syd.logging.cloud.ibm.com`    | 166.9.52.5  \n 166.9.56.20                  | TCP 443  \n TCP 80 | 
-| `Tokyo (jp-tok)`         | `logs.private.jp-tok.logging.cloud.ibm.com`    | 166.9.40.3  \n 166.9.42.4                   | TCP 443  \n TCP 80 | 
-| `Toronto (ca-tor)`       | `logs.private.ca-tor.logging.cloud.ibm.com`    | 166.9.77.26  \n 166.9.76.29                 | TCP 443  \n TCP 80 | 
-| `Washington (us-east)`   | `logs.private.us-east.logging.cloud.ibm.com`   | 166.9.22.36  \n 166.9.20.73                 | TCP 443  \n TCP 80 | 
+| Region                   | Private endpoint                               | Private IP addresses                         | Ports              |
+|--------------------------|------------------------------------------------|----------------------------------------------|--------------------|
+| `Chennai (in-che)`       | `logs.private.in-che.logging.cloud.ibm.com`    | 166.9.60.7                                   | TCP 443  \n TCP 80 |
+| `Dallas (us-south)`      | `logs.private.us-south.logging.cloud.ibm.com`  | 166.9.14.3   \n 166.9.12.13 \n 166.9.16.12   | TCP 443  \n TCP 80 |
+| `Frankfurt (eu-de)`      | `logs.private.eu-de.logging.cloud.ibm.com`     | 166.9.28.3   \n 166.9.32.21                  | TCP 443  \n TCP 80 |
+| `London (eu-gb)`         | `logs.private.eu-gb.logging.cloud.ibm.com`     | 166.9.36.3   \n 166.9.34.4  \n 166.9.38.5    | TCP 443  \n TCP 80 |
+| `Osaka (jp-osa)`         | `logs.private.jp-osa.logging.cloud.ibm.com`    | 166.9.71.20  \n 166.9.70.21 \n 166.9.72.21   | TCP 443  \n TCP 80 |
+| `Sao Paulo (br-sao)`     | `logs.private.br-sao.logging.cloud.ibm.com`    | 166.9.83.25  \n 166.9.84.27 \n 166.9.82.25   | TCP 443  \n TCP 80 |
+| `Seoul (kr-seo)`         | `logs.private.kr-seo.logging.cloud.ibm.com`    | 166.9.40.112 \n 166.9.42.121 \n 166.9.44.111 | TCP 443  \n TCP 80 |
+| `Sydney (au-syd)`        | `logs.private.au-syd.logging.cloud.ibm.com`    | 166.9.52.5   \n 166.9.56.20                  | TCP 443  \n TCP 80 |
+| `Tokyo (jp-tok)`         | `logs.private.jp-tok.logging.cloud.ibm.com`    | 166.9.40.3   \n 166.9.42.4                   | TCP 443  \n TCP 80 |
+| `Toronto (ca-tor)`       | `logs.private.ca-tor.logging.cloud.ibm.com`    | 166.9.77.26  \n 166.9.76.29                  | TCP 443  \n TCP 80 |
+| `Washington (us-east)`   | `logs.private.us-east.logging.cloud.ibm.com`   | 166.9.22.36  \n 166.9.20.73                  | TCP 443  \n TCP 80 |
 {: caption="Table 4. Lists of private ingestion endpoints for interacting with {{site.data.keyword.la_full_notm}}" caption-side="top"}
 
 
@@ -147,19 +147,19 @@ The following table shows the private ingestion endpoints:
 
 The following table shows the logging web UI endpoints:
 
-| Location                 | Region                   |  Public Endpoint                                   | 
+| Location                 | Region                   |  Public Endpoint                                   |
 |--------------------------|--------------------------|----------------------------------------------------|
-| `Asia Pacific`           | `Chennai (in-che)`       | `https://app.in-che.logging.cloud.ibm.com`         | 
-| `Asia Pacific`           | `Osaka (jp-osa)`         | `https://app.jp-osa.logging.cloud.ibm.com`         | 
-| `Asia Pacific`           | `Seoul (kr-seo)`         | `https://app.kr-seo.logging.cloud.ibm.com`         | 
-| `Asia Pacific`           | `Sydney (au-syd)`        | `https://app.au-syd.logging.cloud.ibm.com`         | 
-| `Asia Pacific`           | `Tokyo (jp-tok)`         | `https://app.jp-tok.logging.cloud.ibm.com`         | 
-| `Europe`                 | `Frankfurt (eu-de)`      | `https://app.eu-de.logging.cloud.ibm.com`          | 
-| `Europe`                 | `London (eu-gb)`         | `https://app.eu-gb.logging.cloud.ibm.com`          | 
-| `North America`          | `Dallas (us-south)`      | `https://app.us-south.logging.cloud.ibm.com`       | 
-| `North America`          | `Washington DC (us-east)`| `https://app.us-east.logging.cloud.ibm.com`        | 
-| `North America`          | `Toronto (ca-tor)`       | `https://app.ca-tor.logging.cloud.ibm.com`         | 
-| `South America`          | `Sao Paulo (br-sao)`     | `https://app.br-sao.logging.cloud.ibm.com`         | 
+| `Asia Pacific`           | `Chennai (in-che)`       | `https://app.in-che.logging.cloud.ibm.com`         |
+| `Asia Pacific`           | `Osaka (jp-osa)`         | `https://app.jp-osa.logging.cloud.ibm.com`         |
+| `Asia Pacific`           | `Seoul (kr-seo)`         | `https://app.kr-seo.logging.cloud.ibm.com`         |
+| `Asia Pacific`           | `Sydney (au-syd)`        | `https://app.au-syd.logging.cloud.ibm.com`         |
+| `Asia Pacific`           | `Tokyo (jp-tok)`         | `https://app.jp-tok.logging.cloud.ibm.com`         |
+| `Europe`                 | `Frankfurt (eu-de)`      | `https://app.eu-de.logging.cloud.ibm.com`          |
+| `Europe`                 | `London (eu-gb)`         | `https://app.eu-gb.logging.cloud.ibm.com`          |
+| `North America`          | `Dallas (us-south)`      | `https://app.us-south.logging.cloud.ibm.com`       |
+| `North America`          | `Washington DC (us-east)`| `https://app.us-east.logging.cloud.ibm.com`        |
+| `North America`          | `Toronto (ca-tor)`       | `https://app.ca-tor.logging.cloud.ibm.com`         |
+| `South America`          | `Sao Paulo (br-sao)`     | `https://app.br-sao.logging.cloud.ibm.com`         |
 {: caption="Table 5. Lists of UI endpoints" caption-side="top"}
 
 
@@ -173,56 +173,73 @@ The following table shows the logging web UI endpoints:
 
 The following tables show the syslog public endpoints:
 
-| Region                   |  Public Endpoint                                   | IP addresses                                           | 
+| Region                   |  Public Endpoint                                   | IP addresses                                           |
 |--------------------------|----------------------------------------------------|--------------------------------------------------------|
-| `Chennai (in-che)`       | `syslog://syslog-a.in-che.logging.cloud.ibm.com`   | 169.38.75.43                                           | 
-| `Dallas (us-south)`      | `syslog://syslog-a.us-south.logging.cloud.ibm.com` | 52.117.134.206  \n 52.116.247.170  \n 67.228.102.117   | 
-| `Frankfurt (eu-de)`      | `syslog://syslog-a.eu-de.logging.cloud.ibm.com`    | 149.81.108.28  \n 161.156.78.138  \n 158.177.157.70    | 
-| `London (eu-gb)`         | `syslog://syslog-a.eu-gb.logging.cloud.ibm.com`    | 141.125.102.148  \n 158.175.113.22  \n 158.176.163.115 | 
-| `Osaka (jp-osa)`         | `syslog://syslog-a.jp-osa.logging.cloud.ibm.com`   | 163.73.68.45  \n 163.69.67.210  \n 163.68.72.220       | 
-| `Sao Paulo (br-sao)`     | `syslog://syslog-a.br-sao.logging.cloud.ibm.com`   | 169.57.254.118  \n 163.107.68.195  \n 163.109.68.109   | 
-| `Seoul (kr-seo)`         | `syslog://syslog-a.kr-seo.logging.cloud.ibm.com`   | 169.56.98.139                                          | 
-| `Sydney (au-syd)`        | `syslog://syslog-a.au-syd.logging.cloud.ibm.com`   | 168.1.202.76  \n 135.90.92.254  \n 130.198.1.210       | 
-| `Tokyo (jp-tok)`         | `syslog://syslog-a.jp-tok.logging.cloud.ibm.com`   | 169.56.11.251  \n 165.192.100.77  \n 128.168.107.245   |
-| `Toronto (ca-tor)`       | `syslog://syslog-a.ca-tor.logging.cloud.ibm.com`   | 163.75.66.13  \n 169.53.186.154  \n 163.74.69.234      | 
-| `Washington (us-east)`   | `syslog://syslog-a.us-east.logging.cloud.ibm.com`  | 169.61.98.203  \n 169.47.34.203  \n 169.60.121.243     | 
-{: caption="Table 6. List of syslog-a public endpoints" caption-side="top"}
+| `Chennai (in-che)`       | `syslog://syslog-a.in-che.logging.cloud.ibm.com`   | 169.38.75.43                                           |
+| `Dallas (us-south)`      | `syslog://syslog-a.us-south.logging.cloud.ibm.com` | 52.117.134.206  \n 52.116.247.170 \n 67.228.102.117    |
+| `Frankfurt (eu-de)`      | `syslog://syslog-a.eu-de.logging.cloud.ibm.com`    | 149.81.108.28   \n 161.156.78.138 \n 158.177.157.70    |
+| `London (eu-gb)`         | `syslog://syslog-a.eu-gb.logging.cloud.ibm.com`    | 141.125.102.148 \n 158.175.113.22 \n 158.176.163.115   |
+| `Osaka (jp-osa)`         | `syslog://syslog-a.jp-osa.logging.cloud.ibm.com`   | 163.73.68.45    \n 163.69.67.210  \n 163.68.72.220     |
+| `Sao Paulo (br-sao)`     | `syslog://syslog-a.br-sao.logging.cloud.ibm.com`   | 169.57.254.118  \n 163.107.68.195 \n 163.109.68.109    |
+| `Seoul (kr-seo)`         | `syslog://syslog-a.kr-seo.logging.cloud.ibm.com`   | 169.56.98.139                                          |
+| `Sydney (au-syd)`        | `syslog://syslog-a.au-syd.logging.cloud.ibm.com`   | 168.1.202.76    \n 135.90.92.254  \n 130.198.1.210     |
+| `Tokyo (jp-tok)`         | `syslog://syslog-a.jp-tok.logging.cloud.ibm.com`   | 169.56.11.251   \n 165.192.100.77 \n 128.168.107.245   |
+| `Toronto (ca-tor)`       | `syslog://syslog-a.ca-tor.logging.cloud.ibm.com`   | 163.75.66.13    \n 169.53.186.154 \n 163.74.69.234     |
+| `Washington (us-east)`   | `syslog://syslog-a.us-east.logging.cloud.ibm.com`  | 169.61.98.203   \n 169.47.34.203  \n 169.60.121.243    |
+{: caption="Table 6. List of syslog TCP public endpoints" caption-side="top"}
 
 
-| Region                   |  Public Endpoint                                   | IP addresses                                          | 
+| Region                   |  Public Endpoint                                   | IP addresses                                          |
 |--------------------------|----------------------------------------------------|-------------------------------------------------------|
-| `Chennai (in-che)`       | `syslog://syslog-u.in-che.logging.cloud.ibm.com`   | 169.38.126.5                                          | 
-| `Dallas (us-south)`      | `syslog://syslog-u.us-south.logging.cloud.ibm.com` | 52.116.247.173  \n 169.60.203.92  \n 67.228.102.116   | 
-| `Frankfurt (eu-de)`      | `syslog://syslog-u.eu-de.logging.cloud.ibm.com`    | 161.156.78.139  \n 149.81.108.30  \n 158.177.143.26   | 
-| `London (eu-gb)`         | `syslog://syslog-u.eu-gb.logging.cloud.ibm.com`    | 158.175.66.210  \n 158.176.163.156  \n 141.125.140.98 | 
-| `Osaka (jp-osa)`         | `syslog://syslog-u.jp-osa.logging.cloud.ibm.com`   | 163.69.68.70  \n 163.73.68.46  \n 163.68.72.219       | 
-| `Sao Paulo (br-sao)`     | `syslog://syslog-u.br-sao.logging.cloud.ibm.com`   | 169.57.152.196  \n 163.107.69.14  \n 163.109.68.100   | 
+| `Chennai (in-che)`       | `syslog://syslog-u.in-che.logging.cloud.ibm.com`   | 169.38.126.5                                          |
+| `Dallas (us-south)`      | `syslog://syslog-u.us-south.logging.cloud.ibm.com` | 52.116.247.173 \n 169.60.203.92   \n 67.228.102.116   |
+| `Frankfurt (eu-de)`      | `syslog://syslog-u.eu-de.logging.cloud.ibm.com`    | 161.156.78.139 \n 149.81.108.30   \n 158.177.143.26   |
+| `London (eu-gb)`         | `syslog://syslog-u.eu-gb.logging.cloud.ibm.com`    | 158.175.66.210 \n 158.176.163.156 \n 141.125.140.98   |
+| `Osaka (jp-osa)`         | `syslog://syslog-u.jp-osa.logging.cloud.ibm.com`   | 163.69.68.70   \n 163.73.68.46    \n 163.68.72.219    |
+| `Sao Paulo (br-sao)`     | `syslog://syslog-u.br-sao.logging.cloud.ibm.com`   | 169.57.152.196 \n 163.107.69.14   \n 163.109.68.100   |
 | `Seoul (kr-seo)`         | `syslog://syslog-u.kr-seo.logging.cloud.ibm.com`   | 169.56.98.141                                         |
-| `Sydney (au-syd)`        | `syslog://syslog-u.au-syd.logging.cloud.ibm.com`   | 135.90.92.253  \n 168.1.27.59  \n 130.198.71.30       | 
-| `Tokyo (jp-tok)`         | `syslog://syslog-u.jp-tok.logging.cloud.ibm.com`   | 165.192.100.76  \n 169.56.11.252  \n 128.168.107.244  | 
-| `Toronto (ca-tor)`       | `syslog://syslog-u.ca-tor.logging.cloud.ibm.com`   | 163.75.66.11  \n  169.55.135.29  \n 163.74.69.236     | 
-| `Washington (us-east)`   | `syslog://syslog-u.us-east.logging.cloud.ibm.com`  | 169.47.34.204  \n 169.61.98.202  \n 169.60.98.91      | 
-{: caption="Table 7. List of syslog-u public endpoints" caption-side="top"}
+| `Sydney (au-syd)`        | `syslog://syslog-u.au-syd.logging.cloud.ibm.com`   | 135.90.92.253  \n 168.1.27.59     \n 130.198.71.30    |
+| `Tokyo (jp-tok)`         | `syslog://syslog-u.jp-tok.logging.cloud.ibm.com`   | 165.192.100.76 \n 169.56.11.252   \n 128.168.107.244  |
+| `Toronto (ca-tor)`       | `syslog://syslog-u.ca-tor.logging.cloud.ibm.com`   | 163.75.66.11   \n 169.55.135.29   \n 163.74.69.236    |
+| `Washington (us-east)`   | `syslog://syslog-u.us-east.logging.cloud.ibm.com`  | 169.47.34.204  \n 169.61.98.202   \n 169.60.98.91     |
+{: caption="Table 7. List of syslog UDP public endpoints" caption-side="top"}
 
 ### Syslog private endpoints 
 {: #endpoints_syslog_private_endpoints}
 
 The following table shows the syslog private endpoints:
 
-| Region                   |  Private Endpoint                                   | IP addresses    |
-|--------------------------|----------------------------------------------------|-----------------|
-| `Dallas (us-south)` | `syslog-a.private.us-south.logging.cloud.ibm.com`   | 166.9.14.5  \n 166.9.12.15  \n 166.9.16.14 |
-| `Frankfurt (eu-de)` | `syslog-a.private.eu-de.logging.cloud.ibm.com`   | 166.9.32.23  \n 166.9.28.5 |
-| `Tokyo (jp-tok)` | `syslog-a.private.jp-tok.logging.cloud.ibm.com`   | 166.9.42.26  \n 166.9.40.23 |
-| `Osaka (jp-osa)`     | `syslog-a.private.jp-osa.logging.cloud.ibm.com`   | 166.9.70.22  \n 166.9.71.22  \n 166.9.72.22 |
-| `Sao Paulo (br-sao)`     | `syslog-a.private.br-sao.logging.cloud.ibm.com`   | 166.9.82.26  \n 166.9.83.22  \n 166.9.84.23 |
-| `Toronto (ca-tor)`     | `syslog-a.private.ca-tor.logging.cloud.ibm.com`   | 166.9.76.31  \n 166.9.77.28  \n 166.9.78.29 |
-| `Sydney (au-syd)`     | `syslog-a.private.au-syd.logging.cloud.ibm.com`   | 166.9.52.8  \n 166.9.56.22 |
-| `Washington (us-east)`     | `syslog-a.private.us-east.logging.cloud.ibm.com`   | 166.9.22.38  \n 166.9.20.76  |
-| `London (eu-gb)`     | `syslog-a.private.eu-gb.logging.cloud.ibm.com`   | 166.9.38.20  \n 166.9.34.18  \n 166.9.36.5 |
-| `Chennai (in-che)`     | `syslog-a.private.in-che.logging.cloud.ibm.com`   | 166.9.60.9 |
-| `Seoul (kr-seo)`     | `syslog-a.private.kr-seo.logging.cloud.ibm.com`   | 166.9.46.8 |
-{: caption="Table 8. Lists of syslog private endpoints" caption-side="top"}
+| Region                   |  Private Endpoint                                 | IP addresses                                 |
+|--------------------------|---------------------------------------------------|----------------------------------------------|
+| `Dallas (us-south)`      | `syslog-a.private.us-south.logging.cloud.ibm.com` | 166.9.14.5  \n 166.9.12.15 \n 166.9.16.14    |
+| `Frankfurt (eu-de)`      | `syslog-a.private.eu-de.logging.cloud.ibm.com`    | 166.9.32.23 \n 166.9.28.5                    |
+| `Tokyo (jp-tok)`         | `syslog-a.private.jp-tok.logging.cloud.ibm.com`   | 166.9.42.26 \n 166.9.40.23                   |
+| `Osaka (jp-osa)`         | `syslog-a.private.jp-osa.logging.cloud.ibm.com`   | 166.9.70.22 \n 166.9.71.22 \n 166.9.72.22    |
+| `Sao Paulo (br-sao)`     | `syslog-a.private.br-sao.logging.cloud.ibm.com`   | 166.9.82.26 \n 166.9.83.22 \n 166.9.84.23    |
+| `Toronto (ca-tor)`       | `syslog-a.private.ca-tor.logging.cloud.ibm.com`   | 166.9.76.31 \n 166.9.77.28 \n 166.9.78.29    |
+| `Sydney (au-syd)`        | `syslog-a.private.au-syd.logging.cloud.ibm.com`   | 166.9.52.8  \n 166.9.56.22                   |
+| `Washington (us-east)`   | `syslog-a.private.us-east.logging.cloud.ibm.com`  | 166.9.22.38 \n 166.9.20.76                   |
+| `London (eu-gb)`         | `syslog-a.private.eu-gb.logging.cloud.ibm.com`    | 166.9.38.20 \n 166.9.34.18  \n 166.9.36.5    |
+| `Chennai (in-che)`       | `syslog-a.private.in-che.logging.cloud.ibm.com`   | 166.9.60.9                                   |
+| `Seoul (kr-seo)`         | `syslog-a.private.kr-seo.logging.cloud.ibm.com`   | 166.9.44.112 \n 166.9.42.122 \n 166.9.40.113 |
+{: caption="Table 8. Lists of syslog TCP private endpoints" caption-side="top"}
+
+
+| Region                   |  Private Endpoint                                 | IP addresses                                 |
+|--------------------------|---------------------------------------------------|----------------------------------------------|
+| `Dallas (us-south)`      | `syslog-u.private.us-south.logging.cloud.ibm.com` | 166.9.14.6  \n 166.9.16.15 \n 166.9.12.16    |
+| `Frankfurt (eu-de)`      | `syslog-u.private.eu-de.logging.cloud.ibm.com`    | 166.9.32.24 \n 166.9.28.7                    |
+| `Tokyo (jp-tok)`         | `syslog-u.private.jp-tok.logging.cloud.ibm.com`   | 166.9.42.27 \n 166.9.40.24                   |
+| `Osaka (jp-osa)`         | `syslog-u.private.jp-osa.logging.cloud.ibm.com`   | 166.9.70.23 \n 166.9.72.23 \n 166.9.71.23    |
+| `Sao Paulo (br-sao)`     | `syslog-u.private.br-sao.logging.cloud.ibm.com`   | 166.9.82.27 \n 166.9.83.26 \n 166.9.84.26    |
+| `Toronto (ca-tor)`       | `syslog-u.private.ca-tor.logging.cloud.ibm.com`   | 166.9.78.30 \n 166.9.77.29 \n 166.9.76.32    |
+| `Sydney (au-syd)`        | `syslog-u.private.au-syd.logging.cloud.ibm.com`   | 166.9.52.9  \n 166.9.56.23                   |
+| `Washington (us-east)`   | `syslog-u.private.us-east.logging.cloud.ibm.com`  | 166.9.22.39 \n 166.9.20.77                   |
+| `London (eu-gb)`         | `syslog-u.private.eu-gb.logging.cloud.ibm.com`    | 166.9.36.6  \n 166.9.38.21  \n 166.9.34.19   |
+| `Chennai (in-che)`       | `syslog-u.private.in-che.logging.cloud.ibm.com`   | 166.9.60.10                                  |
+| `Seoul (kr-seo)`         | `syslog-u.private.kr-seo.logging.cloud.ibm.com`   | 166.9.40.114 \n 166.9.44.103 \n 166.9.42.123 |
+{: caption="Table 8. Lists of syslog UDP private endpoints" caption-side="top"}
+
 
 ### Syslog TLS endpoints
 {: #endpoints_syslog_tls}
@@ -232,17 +249,17 @@ The following table shows the syslog TLS endpoints:
 
 | Region                   |  Public Endpoint                                         | IP addresses                                           |
 |--------------------------|----------------------------------------------------------|--------------------------------------------------------|
-| `Chennai (in-che)`       | `syslog-tls://syslog-a.in-che.logging.cloud.ibm.com`     | 169.38.75.43                                           | 
-| `Dallas (us-south)`      | `syslog-tls://syslog-a.us-south.logging.cloud.ibm.com`   | 52.117.134.203                                         | 
-| `Frankfurt (eu-de)`      | `syslog-tls://syslog-a.eu-de.logging.cloud.ibm.com`      | 161.156.78.138  \n 158.177.157.70  \n 149.81.108.28    | 
-| `London (eu-gb)`         | `syslog-tls://syslog-a.eu-gb.logging.cloud.ibm.com`      | 158.176.163.115 \n 141.125.102.148 \n 158.175.113.22   | 
-| `Sao Paulo (br-sao)`     | `syslog-tls://syslog-a.br-sao.logging.cloud.ibm.com`     | 169.57.254.118  \n 163.107.68.195  \n 163.109.68.109   | 
-| `Osaka (jp-osa)`         | `syslog-tls://syslog-a.jp-osa.logging.cloud.ibm.com`     | 163.69.67.210   \n 163.68.72.220   \n 163.73.68.45     | 
-| `Seoul (kr-seo)`         | `syslog-tls://syslog-a.kr-seo.logging.cloud.ibm.com`     | 169.56.98.139                                          | 
-| `Sydney (au-syd)`        | `syslog-tls://syslog-a.au-syd.logging.cloud.ibm.com`     | 135.90.92.254   \n 168.1.202.76    \n 130.198.1.210    | 
-| `Tokyo (jp-tok)`         | `syslog-tls://syslog-a.jp-tok.logging.cloud.ibm.com`     | 128.168.107.245 \n 165.192.100.77  \n 169.56.11.251    | 
-| `Toronto (ca-tor)`       | `syslog-tls://syslog-a.ca-tor.logging.cloud.ibm.com`     | 163.75.66.13    \n 163.74.69.234   \n 169.53.186.154   | 
-| `Washington (us-east)`   | `syslog-tls://syslog-a.us-east.logging.cloud.ibm.com`    | 169.60.121.243  \n 169.61.98.203   \n 169.47.34.203    | 
+| `Chennai (in-che)`       | `syslog-tls://syslog-a.in-che.logging.cloud.ibm.com`     | 169.38.75.43                                           |
+| `Dallas (us-south)`      | `syslog-tls://syslog-a.us-south.logging.cloud.ibm.com`   | 52.117.134.206  \n 52.116.247.170  \n 67.228.102.117   |
+| `Frankfurt (eu-de)`      | `syslog-tls://syslog-a.eu-de.logging.cloud.ibm.com`      | 161.156.78.138  \n 158.177.157.70  \n 149.81.108.28    |
+| `London (eu-gb)`         | `syslog-tls://syslog-a.eu-gb.logging.cloud.ibm.com`      | 158.176.163.115 \n 141.125.102.148 \n 158.175.113.22   |
+| `Sao Paulo (br-sao)`     | `syslog-tls://syslog-a.br-sao.logging.cloud.ibm.com`     | 169.57.254.118  \n 163.107.68.195  \n 163.109.68.109   |
+| `Osaka (jp-osa)`         | `syslog-tls://syslog-a.jp-osa.logging.cloud.ibm.com`     | 163.69.67.210   \n 163.68.72.220   \n 163.73.68.45     |
+| `Seoul (kr-seo)`         | `syslog-tls://syslog-a.kr-seo.logging.cloud.ibm.com`     | 169.56.98.139                                          |
+| `Sydney (au-syd)`        | `syslog-tls://syslog-a.au-syd.logging.cloud.ibm.com`     | 135.90.92.254   \n 168.1.202.76    \n 130.198.1.210    |
+| `Tokyo (jp-tok)`         | `syslog-tls://syslog-a.jp-tok.logging.cloud.ibm.com`     | 128.168.107.245 \n 165.192.100.77  \n 169.56.11.251    |
+| `Toronto (ca-tor)`       | `syslog-tls://syslog-a.ca-tor.logging.cloud.ibm.com`     | 163.75.66.13    \n 163.74.69.234   \n 169.53.186.154   |
+| `Washington (us-east)`   | `syslog-tls://syslog-a.us-east.logging.cloud.ibm.com`    | 169.60.121.243  \n 169.61.98.203   \n 169.47.34.203    |
 {: caption="Table 9. Lists of Syslog-TLS endpoints" caption-side="top"}
 
 


### PR DESCRIPTION
Previously the syslog UDP endpoints where missing from this document
so lets add them. Also update the kr-seo/Seoul private endpoints as
the IPs have changed after migrating the private load balancers from
the kr-seo data center to jp-tok.